### PR TITLE
fix: export the internal type for the parsed configuration

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import { parseGoConfig } from './parser';
+import { parseGoConfig, GoProjectConfig } from './parser';
 import { GoPackageManagerType } from './types';
 
 interface DepDict {
@@ -16,7 +16,7 @@ export { GoPackageManagerType };
 // To be reused in snyk-go-plugin.
 // The plugin, used by Snyk CLI, also scans source files and thus is able to produce
 // a proper dependency graph.
-export { parseGoConfig };
+export { parseGoConfig, GoProjectConfig };
 
 // Build dep tree from the manifest/lock files only.
 // This does not scan the source code for imports, so it's not accurate;

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -10,7 +10,7 @@ interface LockedDeps {
   [dep: string]: LockedDep;
 }
 
-interface GoProjectConfig {
+export interface GoProjectConfig {
   ignoredPkgs: string[];
   lockedVersions: LockedDeps;
   packageName?: string;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Exports the type of the parsed data so the library can be reused by snyk-go-plugin.
Fix to trigger a new release.

