### PR TITLE
fix: unify package manager name

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-export type GoPackageManagerType = 'golangdep' | 'govendor' | 'gomod';
+export type GoPackageManagerType = 'golangdep' | 'govendor' | 'gomodules';
 
 export interface LockedDep {
   name: string;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Moving from `gomod` to `gomodules` as a name for Go Modules package manager.