### PR TITLE
fix: Update TS, remove duplicate type def

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,16 +2,6 @@ import { parseGoPkgConfig, parseGoVendorConfig } from './parser';
 import { parseGoMod, toSnykVersion, parseVersion } from './gomod-parser';
 import { DepTree, GoPackageManagerType, GoProjectConfig, ModuleVersion, GoMod } from './types';
 
-interface DepDict {
-  [dep: string]: DepTree;
-}
-
-export interface DepTree {
-  name: string;
-  version: string;
-  dependencies?: DepDict;
-}
-
 export { GoPackageManagerType };
 
 // To be reused in snyk-go-plugin.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "ts-jest": "^23.10.5",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",
-    "typescript": "^3.4.0"
+    "typescript": "^3.7.2"
   }
 }


### PR DESCRIPTION
Updates TS to 3.7.x and removes a duplicate type definition that was flagged by the compiler in the process