### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/snyk/snyk-go-parser#readme",
   "dependencies": {
     "toml": "^3.0.0",
-    "tslib": "^1.9.3"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@types/jest": "^23.3.14",
@@ -35,6 +35,6 @@
     "ts-jest": "^23.10.5",
     "ts-node": "7.0.0",
     "tslint": "5.11.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "lib": ["es2017", "es5", "es2015.promise"],
-    "target": "es5",
+    "lib": ["es2015"],
+    "target": "es2015",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.
