### PR TITLE
fix: fetch project name from go.mod file

### DIFF
--- a/lib/parsers/gomod-graph-parser.ts
+++ b/lib/parsers/gomod-graph-parser.ts
@@ -15,15 +15,23 @@ export function parseGoModGraph(
   projectName: string,
   projectVersion: string = DEFAULT_INITIAL_VERSION,
 ): DepGraph {
-  const rootPkgInfo = { name: projectName, version: projectVersion };
-  const depGraph = new DepGraphBuilder({ name: GO_MODULES }, rootPkgInfo);
+  const rootPkgInfo = {
+    name: projectName.length ? projectName : '',
+    version: projectVersion,
+  };
+  let depGraph = new DepGraphBuilder({ name: GO_MODULES }, rootPkgInfo);
 
   for (const line of goModGraphOutput.trim().split('\n')) {
     const [
       [parentName, parentVersion = DEFAULT_INITIAL_VERSION],
       [childName, childVersion],
     ] = parseGoModGraphLine(line);
+    if (!rootPkgInfo.name?.length) {
+      rootPkgInfo.name = parentName; // On first iteration we populate w/ the module name
 
+      // If we updated the package name, we should update to a new DepGraphBuilder
+      depGraph = new DepGraphBuilder({ name: GO_MODULES }, rootPkgInfo);
+    }
     const parentPkg: PkgInfo = { name: parentName, version: parentVersion };
     const childPkg: PkgInfo = {
       name: childName,


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Currently we supply the depGraph builder with the project name. However, this is used also in the deps-service, which doesn't have access to the project name; This way we make the projectName conditional so if the name isn't set --> it will be fetched from the `go.mod` file

