### PR TITLE
fix: support empty go mod graph results

### DIFF
--- a/lib/parsers/gomod-graph-parser.ts
+++ b/lib/parsers/gomod-graph-parser.ts
@@ -15,10 +15,13 @@ export function parseGoModGraph(
   projectName: string,
   projectVersion: string = DEFAULT_INITIAL_VERSION,
 ): DepGraph {
-  const iterationReadyGraph = goModGraphOutput.trim().split('\n');
-  const moduleName = iterationReadyGraph[0].split(/\s/)[0];
+  const iterationReadyGraph = goModGraphOutput
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  const moduleName = iterationReadyGraph[0]?.split(/\s/)[0];
   const rootPkgInfo = {
-    name: projectName || moduleName,
+    name: projectName || moduleName || 'empty',
     version: projectVersion,
   };
   const depGraph = new DepGraphBuilder({ name: GO_MODULES }, rootPkgInfo);

--- a/test/fixtures/gomod/empty/expected-graph.json
+++ b/test/fixtures/gomod/empty/expected-graph.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "gomodules"
+  },
+  "pkgs": [
+    {
+      "id": "empty@0.0.0",
+      "info": {
+        "name": "empty",
+        "version": "0.0.0"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "empty@0.0.0",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/test/fixtures/gomod/empty/go.mod
+++ b/test/fixtures/gomod/empty/go.mod
@@ -1,0 +1,1 @@
+module github.com/spf13/jwalterweatherman

--- a/test/gomodgraph.test.ts
+++ b/test/gomodgraph.test.ts
@@ -12,3 +12,14 @@ it('simple example: gomod parsing', async () => {
   const expectedGraph = createFromJSON(JSON.parse(load(path.join('gomod', 'simple', 'expected-graph.json'))));
   expect(goModGraph.equals(expectedGraph, {compareRoot: true})).toBe(true);
 });
+
+it('empty example: gomod parsing', async () => {
+  const exampleGoMod = load(path.join('gomod', 'empty', 'gomodgraph'));
+  const goModGraph = parseGoModGraph(exampleGoMod, '');
+  const expectedGraph = createFromJSON(JSON.parse(load(path.join('gomod', 'empty', 'expected-graph.json'))));
+  try {
+    expect(goModGraph.equals(expectedGraph, {compareRoot: true})).toBe(true);
+  } catch (e) {
+    expect(goModGraph.toJSON()).toEqual(expectedGraph.toJSON());
+  }
+});


### PR DESCRIPTION
Add support for empty `go mod graph` results