### PR TITLE
feat: add eventLoopSpinner

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,7 +40,7 @@ export async function buildGoPkgDepTree(
   options?: unknown,
 ): Promise<DepTree> {
   return buildGoDepTree(
-    parseGoPkgConfig(manifestFileContents, lockFileContents),
+    await parseGoPkgConfig(manifestFileContents, lockFileContents),
   );
 }
 
@@ -50,7 +50,7 @@ export async function buildGoPkgDepTree(
 export async function buildGoVendorDepTree(
   manifestFileContents: string,
 ): Promise<DepTree> {
-  return buildGoDepTree(parseGoVendorConfig(manifestFileContents));
+  return buildGoDepTree(await parseGoVendorConfig(manifestFileContents));
 }
 
 function buildGoDepTree(goProjectConfig: GoPackageConfig) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/snyk/snyk-go-parser#readme",
   "dependencies": {
     "@snyk/dep-graph": "^1.20.0",
+    "event-loop-spinner": "^2.1.0",
     "toml": "^3.0.0",
     "tslib": "^1.10.0"
   },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
According to https://snyksec.atlassian.net/browse/LOKI-298, running `buildGoPkgDepTree` in a synchronous way is the 3rd worst block in registry
This PR adds the eventLoopSpinner to better handle this problem (until will move the entire parsing to `golang-deps` service)