### PR TITLE
fix: semver in root package

### DIFF
--- a/lib/parsers/gomod-graph-parser.ts
+++ b/lib/parsers/gomod-graph-parser.ts
@@ -25,9 +25,8 @@ export function parseGoModGraph(
     .trim()
     .split('\n')
     .filter(Boolean);
-  const moduleName = iterationReadyGraph[0]?.split(/\s/)[0];
   const rootPkgInfo = {
-    name: projectName || moduleName || 'empty',
+    name: projectName || getModuleName(iterationReadyGraph[0]),
     version: projectVersion,
   };
   const depGraph = new DepGraphBuilder({ name: GO_MODULES }, rootPkgInfo);
@@ -56,4 +55,9 @@ export function parseGoModGraph(
   }
 
   return depGraph.build();
+}
+
+function getModuleName(firstLine = '') {
+  const [[moduleName]] = parseGoModGraphLine(firstLine);
+  return moduleName || 'empty';
 }

--- a/test/fixtures/gomod/semver-prefixed/go.mod
+++ b/test/fixtures/gomod/semver-prefixed/go.mod
@@ -1,4 +1,4 @@
-module github.com/snyk/snyko
+module github.com/snyk/snyko/v3
 
 go 1.15
 

--- a/test/fixtures/gomod/semver-prefixed/gomodgraph
+++ b/test/fixtures/gomod/semver-prefixed/gomodgraph
@@ -1,3 +1,3 @@
-github.com/snyk/snyko github.com/dgrijalva/jwt-go@v3.2.0+incompatible
-github.com/snyk/snyko github.com/dgrijalva/jwt-go/v4@v4.0.0-preview1
+github.com/snyk/snyko/v3 github.com/dgrijalva/jwt-go@v3.2.0+incompatible
+github.com/snyk/snyko/v3 github.com/dgrijalva/jwt-go/v4@v4.0.0-preview1
 github.com/dgrijalva/jwt-go/v4@v4.0.0-preview1 golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543


### PR DESCRIPTION
today if the root package has a version in it (i.e. /v2)
the root node will be generated without any dependencies

this fixes the issue.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team