### PR TITLE
feat: added a go version directive parser for gomodules

### DIFF
--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,4 +1,5 @@
 export { InvalidUserInputError } from './invalid-user-input-error';
+export { MissingGoModVersionDirectiveError } from './missing-go-mod-version-directive-error';
 
 // Other common parser error types:
 

--- a/lib/errors/missing-go-mod-version-directive-error.ts
+++ b/lib/errors/missing-go-mod-version-directive-error.ts
@@ -1,0 +1,9 @@
+export class MissingGoModVersionDirectiveError extends Error {
+  public code = 422;
+  public name = 'MissingGoModVersionDirectiveError';
+
+  constructor(...args: any) {
+    super(...args);
+    Error.captureStackTrace(this, MissingGoModVersionDirectiveError);
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ import {
   parseGoVendorConfig,
   parseGoModGraph,
   parseGoModRelativeManifestReplaces,
+  parseGoModVersionDirective,
 } from './parsers';
 import {
   DepTree,
@@ -23,6 +24,7 @@ export {
   parseGoVendorConfig,
   parseGoModGraph,
   parseGoModRelativeManifestReplaces,
+  parseGoModVersionDirective,
   GoPackageConfig,
   ModuleVersion,
   GoModuleConfig,

--- a/lib/parsers/gomod-version-directive-parser.ts
+++ b/lib/parsers/gomod-version-directive-parser.ts
@@ -11,7 +11,7 @@ const GoVersionRE = /^go\s(?<version>([1-9][0-9]*)\.(0|[1-9][0-9]*))/m;
 export function parseGoModVersionDirective(
   goModFileContent: string,
   strict = true,
-): string | undefined | MissingGoModVersionDirectiveError {
+): string | undefined {
   const version = GoVersionRE.exec(goModFileContent);
 
   if (!version) {
@@ -23,6 +23,5 @@ export function parseGoModVersionDirective(
     }
     return undefined;
   }
-
   return version[1];
 }

--- a/lib/parsers/gomod-version-directive-parser.ts
+++ b/lib/parsers/gomod-version-directive-parser.ts
@@ -18,7 +18,7 @@ export function parseGoModVersionDirective(
     if (strict) {
       // No strict version was found, and we needed one to be defined.
       throw new MissingGoModVersionDirectiveError(
-        'go.mod file must have a go version directive and must match format 1.23',
+        'go.mod file must have a go version directive and must match format {major}.{minor} (e.g. 1.23)',
       );
     }
     return undefined;

--- a/lib/parsers/gomod-version-directive-parser.ts
+++ b/lib/parsers/gomod-version-directive-parser.ts
@@ -1,0 +1,28 @@
+import { MissingGoModVersionDirectiveError } from '../errors';
+
+// Parse the Go version directive from the go.mod file, if defined.
+// The logic is more or less identical to the actual `go` command's. See more here:
+// https://cs.opensource.google/go/x/mod/+/7c05a442b7c1d1a107879b4a090bb5a38d3774a1:modfile/rule.go;l=342-362
+const GoVersionRE = /^go\s(?<version>([1-9][0-9]*)\.(0|[1-9][0-9]*))/m;
+
+// Attempt to parse the go directive out of a go.mod file, either in strict mode or not.
+// If strict mode, will cause a failure if no version is found, otherwise just return undefined.
+// Both options are available as different versions of the go cli tool have acted differently around this issue.
+export function parseGoModVersionDirective(
+  goModFileContent: string,
+  strict = true,
+): string | undefined | MissingGoModVersionDirectiveError {
+  const version = GoVersionRE.exec(goModFileContent);
+
+  if (!version) {
+    if (strict) {
+      // No strict version was found, and we needed one to be defined.
+      throw new MissingGoModVersionDirectiveError(
+        'go.mod file must have a go version directive and must match format 1.23',
+      );
+    }
+    return undefined;
+  }
+
+  return version[1];
+}

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -2,3 +2,4 @@ export { parseGoModGraph } from './gomod-graph-parser';
 export { parseGoVendorConfig } from './govendor-parser';
 export { parseGoPkgConfig } from './gopkg-parser';
 export { parseGoModRelativeManifestReplaces } from './gomod-relative-manifest-parser';
+export { parseGoModVersionDirective } from './gomod-version-directive-parser';

--- a/test/gomod.test.ts
+++ b/test/gomod.test.ts
@@ -1,14 +1,70 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { parseGoModRelativeManifestReplaces } from '../lib/parsers/gomod-relative-manifest-parser';
+import {
+  parseGoModRelativeManifestReplaces,
+  parseGoModVersionDirective,
+} from '../lib';
+import { MissingGoModVersionDirectiveError } from '../lib/errors';
 
 const load = (filename: string) =>
-    fs.readFileSync(`${__dirname}/fixtures/${filename}`, 'utf8');
+  fs.readFileSync(`${__dirname}/fixtures/${filename}`, 'utf8');
 
 describe('go mod suite', () => {
   it('parseGoModRelativeManifestReplaces should return all relative manifest files', async () => {
     const exampleGoMod = load(path.join('gomod', 'big', 'go.mod'));
-    const relativeManifestFiles = parseGoModRelativeManifestReplaces(exampleGoMod);
+    const relativeManifestFiles = parseGoModRelativeManifestReplaces(
+      exampleGoMod,
+    );
     expect(relativeManifestFiles).toMatchSnapshot();
   });
+
+  it.each([
+    {
+      fixtureFolderName: 'big',
+      expectedVersion: '1.12',
+      strict: false,
+      shouldFail: false,
+    },
+    {
+      fixtureFolderName: 'semver-prefixed',
+      expectedVersion: '1.15',
+      strict: true,
+      shouldFail: false,
+    },
+    {
+      fixtureFolderName: 'simple',
+      expectedVersion: undefined,
+      strict: false,
+      shouldFail: false,
+    },
+    {
+      fixtureFolderName: 'empty',
+      expectedVersion: undefined,
+      strict: false,
+      shouldFail: false,
+    },
+    {
+      fixtureFolderName: 'empty',
+      expectedVersion: undefined,
+      strict: true,
+      shouldFail: true,
+    },
+  ])(
+    'should extract the version $expectedVersion when reading the go.mod file in folder "$fixtureFolderName"',
+    ({ fixtureFolderName, expectedVersion, strict, shouldFail }) => {
+      const exampleGoMod = load(
+        path.join('gomod', fixtureFolderName, 'go.mod'),
+      );
+
+      if (shouldFail) {
+        expect(() => parseGoModVersionDirective(exampleGoMod, strict)).toThrow(
+          MissingGoModVersionDirectiveError,
+        );
+        return;
+      }
+
+      const actualVersion = parseGoModVersionDirective(exampleGoMod, strict);
+      expect(actualVersion).toBe(expectedVersion);
+    },
+  );
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

A go directive indicates that a module was written assuming the semantics of a given version of Go. The go directive was originally intended to support backward incompatible changes to the Go language. 

The `go.mod` file can decide to include a version or not, and this change will allow plugins or other consumers of this parser to get a version from a `go.mod` file, or `undefined` in case none exists. (In newer versions of the `go mod` CLI, this defaults to 1.16, but this behavior is not reproduced here).

Alternatively you can decide to parse it in strict mode, which will cause an error to be thrown in case the directive is not correctly defined in the `go.mod` file.

#### What are the relevant tickets?

This is a PR that will help certain internal Snyk models better behave closer to the customer's own ecosystems by parsing and supplying the Go version used to build the project we are investigating.

