### PR TITLE
feat: add parseGoSum for go.sum module hashes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,11 +4,14 @@ import {
   parseGoModGraph,
   parseGoModRelativeManifestReplaces,
   parseGoModVersionDirective,
+  parseGoSum,
 } from './parsers';
 import {
   DepTree,
   GoPackageManagerType,
   GoPackageConfig,
+  GoSumEntry,
+  GoSumEntries,
   ModuleVersion,
   GoModuleConfig,
   DEFAULT_INITIAL_VERSION,
@@ -25,7 +28,10 @@ export {
   parseGoModGraph,
   parseGoModRelativeManifestReplaces,
   parseGoModVersionDirective,
+  parseGoSum,
   GoPackageConfig,
+  GoSumEntry,
+  GoSumEntries,
   ModuleVersion,
   GoModuleConfig,
 };

--- a/lib/parsers/gosum-parser.ts
+++ b/lib/parsers/gosum-parser.ts
@@ -1,0 +1,40 @@
+import { GoSumEntries } from '../types';
+
+const GO_MOD_SUFFIX = '/go.mod';
+
+// Parse the contents of a go.sum file into a map keyed by `<module>@<version>`.
+// Each module version can have up to two entries in a go.sum file:
+//   <module> <version> h1:<base64>=          -> hash of the module's file tree (the .zip)
+//   <module> <version>/go.mod h1:<base64>=   -> hash of the module's go.mod file
+// The hash values are stored verbatim (e.g. "h1:abc...="); callers decide how to
+// decode them. See https://go.dev/ref/mod#go-sum-files
+export function parseGoSum(goSumContents: string): GoSumEntries {
+  const entries: GoSumEntries = {};
+
+  for (const rawLine of goSumContents.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    const [modulePath, versionField, hash] = line.split(/\s+/);
+    if (!modulePath || !versionField || !hash) {
+      continue; // malformed line, skip it
+    }
+
+    const isGoMod = versionField.endsWith(GO_MOD_SUFFIX);
+    const version = isGoMod
+      ? versionField.slice(0, -GO_MOD_SUFFIX.length)
+      : versionField;
+
+    const key = `${modulePath}@${version}`;
+    const entry = entries[key] || (entries[key] = {});
+    if (isGoMod) {
+      entry.goModH1 = hash;
+    } else {
+      entry.h1 = hash;
+    }
+  }
+
+  return entries;
+}

--- a/lib/parsers/index.ts
+++ b/lib/parsers/index.ts
@@ -3,3 +3,4 @@ export { parseGoVendorConfig } from './govendor-parser';
 export { parseGoPkgConfig } from './gopkg-parser';
 export { parseGoModRelativeManifestReplaces } from './gomod-relative-manifest-parser';
 export { parseGoModVersionDirective } from './gomod-version-directive-parser';
+export { parseGoSum } from './gosum-parser';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -65,5 +65,14 @@ export interface DepTree {
   };
 }
 
+export interface GoSumEntry {
+  h1?: string; // hash of the module's file tree, verbatim "h1:..." value from go.sum
+  goModH1?: string; // hash of the module's go.mod file, verbatim "h1:..." value
+}
+
+export interface GoSumEntries {
+  [moduleAtVersion: string]: GoSumEntry;
+}
+
 export const DEFAULT_INITIAL_VERSION = '0.0.0';
 export const DEFAULT_ROOT_NODE_NAME = 'root-node';

--- a/test/fixtures/gosum/simple/go.sum
+++ b/test/fixtures/gosum/simple/go.sum
@@ -1,0 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/test/gosum.test.ts
+++ b/test/gosum.test.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseGoSum } from '../lib';
+
+const load = (filename: string) =>
+  fs.readFileSync(`${__dirname}/fixtures/${filename}`, 'utf8');
+
+describe('parseGoSum', () => {
+  it('maps module@version to its file-tree and go.mod hashes', () => {
+    const goSum = load(path.join('gosum', 'simple', 'go.sum'));
+
+    const entries = parseGoSum(goSum);
+
+    expect(entries['github.com/davecgh/go-spew@v1.1.0']).toEqual({
+      h1: 'h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=',
+      goModH1: 'h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=',
+    });
+    expect(entries['golang.org/x/text@v0.3.2']).toEqual({
+      h1: 'h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=',
+      goModH1: 'h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=',
+    });
+  });
+
+  it('records a go.mod-only entry without a file-tree hash', () => {
+    const entries = parseGoSum(load(path.join('gosum', 'simple', 'go.sum')));
+
+    expect(entries['github.com/stretchr/objx@v0.1.0']).toEqual({
+      goModH1: 'h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=',
+    });
+  });
+
+  it('ignores blank and malformed lines', () => {
+    const entries = parseGoSum(
+      [
+        '',
+        '   ',
+        'github.com/only/two-fields v1.0.0',
+        'github.com/valid/mod v1.2.3 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=',
+      ].join('\n'),
+    );
+
+    expect(Object.keys(entries)).toEqual(['github.com/valid/mod@v1.2.3']);
+    expect(entries['github.com/valid/mod@v1.2.3']).toEqual({
+      h1: 'h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=',
+    });
+  });
+
+  it('returns an empty map for empty input', () => {
+    expect(parseGoSum('')).toEqual({});
+  });
+});


### PR DESCRIPTION
## What

Adds `parseGoSum`, which parses a `go.sum` file into a map of `<module>@<version>` → its recorded hashes:

- `h1` — the module file-tree hash (the `h1:...` value from the non-`/go.mod` line)
- `goModH1` — the module's `go.mod` hash

Values are kept verbatim; callers decide how to decode them. Blank and malformed lines are skipped.

## Why

`snyk-go-plugin` is gaining support for the `includeComponentMetadata` flag (as already exists for Maven and npm), which attaches integrity hashes and distribution URLs to Go dependency-graph nodes. `go.sum` is the natural, native source of those module hashes, and parsing lockfiles belongs here in the parser rather than in the plugin.

## Consumer

The companion change is snyk/snyk-go-plugin#148, which decodes the `h1:` value to a hex SHA-256 label and derives a module-proxy distribution URL.

## Notes

- Scope is the modern go modules (`go.mod`) path only; the legacy dep/govendor formats have no `go.sum`.